### PR TITLE
Connect to DB with ENV Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ To test the app
 
 ### yarn start
 To start the server. You an then try hitting the available endpoints (see terminal).
+
+### Connection Strings
+For security, connection strings are set on the Azure Portal. Check out the `PG_DB_CONNECTION_STRING` ENV variable for this function when logged into the portal. For local testing, this variable can be set in the `local.settings.json` file. Just be careful not to commit any sensitive information when testing. 
+
+### Deployment
+Deploying an Azure Function is simple, using the Azure VS Code extension. You can follow steps [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code?pivots=programming-language-javascript#publish-the-project-to-azure) on how to publish a function. 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ For security, connection strings are set on the Azure Portal. Check out the `PG_
 
 ### Deployment
 Deploying an Azure Function is simple, using the Azure VS Code extension. You can follow steps [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code?pivots=programming-language-javascript#publish-the-project-to-azure) on how to publish a function. 
+
+#### Staging or Production?
+Although you could use Azure [Slots](https://docs.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots) to handle different environments, you can also deploy the same function at a different location (eg. `mapping-viz-functions-staging` vs `mapping-viz-functions`) and set a different connection string at each endpoint to handle staging and production databases.

--- a/subjects/index.js
+++ b/subjects/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = process.env['AzureWebJobsStorage']
+    const connectionString = process.env['PG_DB_CONNECTION_STRING']
     const client = new pg.Client({ connectionString })
 
     const { maxLat, minLat, maxLon, minLon } = params

--- a/subjects/index.js
+++ b/subjects/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = process.env['PG_DB_CONNECTION_STRING']
+    const connectionString = process.env['PG_DB_CONNECTION_STRING'] || 'postgres://postgres:postgres@localhost:5432/sample_db'
     const client = new pg.Client({ connectionString })
 
     const { maxLat, minLat, maxLon, minLon } = params

--- a/subjects/index.js
+++ b/subjects/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = 'postgres://postgres:postgres@localhost:5432/sample_db'
+    const connectionString = process.env['AzureWebJobsStorage']
     const client = new pg.Client({ connectionString })
 
     const { maxLat, minLat, maxLon, minLon } = params

--- a/temperature/index.js
+++ b/temperature/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = process.env['PG_DB_CONNECTION_STRING']
+    const connectionString = process.env['PG_DB_CONNECTION_STRING'] || 'postgres://postgres:postgres@localhost:5432/sample_db'
     const client = new pg.Client({ connectionString })
 
     const { grid_index } = params

--- a/temperature/index.js
+++ b/temperature/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = process.env['AzureWebJobsStorage']
+    const connectionString = process.env['PG_DB_CONNECTION_STRING']
     const client = new pg.Client({ connectionString })
 
     const { grid_index } = params

--- a/temperature/index.js
+++ b/temperature/index.js
@@ -2,7 +2,7 @@ const pg = require('pg');
 const performQuery = require('../helpers/performQuery').default
 
 async function executeSQL(context, params) {
-    const connectionString = 'postgres://postgres:postgres@localhost:5432/sample_db'
+    const connectionString = process.env['AzureWebJobsStorage']
     const client = new pg.Client({ connectionString })
 
     const { grid_index } = params


### PR DESCRIPTION
This PR changes the connection string from one used in local testing to an ENV variable that should be set on the portal. There's also a bit of README information on how to publish/deploy in the future.