### PR TITLE
Update schema.sql to pg v11 dump

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,60 +2,18 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.20
--- Dumped by pg_dump version 9.5.23
+-- Dumped from database version 11.6
+-- Dumped by pg_dump version 11.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
--- Name: pg_buffercache; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_buffercache WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_buffercache; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_buffercache IS 'examine the shared buffer cache';
-
-
---
--- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
-
 
 SET default_tablespace = '';
 
@@ -131,21 +89,21 @@ ALTER SEQUENCE public.temperatures_id_seq OWNED BY public.temperatures.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: subjects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subjects ALTER COLUMN id SET DEFAULT nextval('public.subjects_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: temperatures id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.temperatures ALTER COLUMN id SET DEFAULT nextval('public.temperatures_id_seq'::regclass);
 
 
 --
--- Name: subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: subjects subjects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subjects
@@ -153,7 +111,7 @@ ALTER TABLE ONLY public.subjects
 
 
 --
--- Name: temperatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: temperatures temperatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.temperatures


### PR DESCRIPTION
This schema file is a direct dump from the existing Postgres v11 database via `pg_dump --schema-only --no-acl --no-owner` as suggested in the readme. Not sure why the extension definitions are gone--perhaps they were never migrated over. Assuming they're not critical, if you find that they need to be installed again, we can do that in a new PR.